### PR TITLE
 Open Get date and interim numbers

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.12.x, 1.18.x]
+        go-version: [1.12.x, 1.20.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,3 @@ github.com/frozzare/go v1.0.0 h1:aMEQSDLZ9RRodFq03p9eFi10Oxg4YNek29a0ul86tc4=
 github.com/frozzare/go v1.0.0/go.mod h1:aF04gf7/Kbc1nTC3XyPCgWEBIpnRjhsGQ1aj4bCVxxk=
 github.com/frozzare/go-assert v1.1.0 h1:JaWK+Q2bFyVyE8dpUNtqh0P9CFAwtQhTiKZiwJ8R+Mc=
 github.com/frozzare/go-assert v1.1.0/go.mod h1:qaUtLVkASIEqsHEn8xhGKLh+24s1y07Y88Z5mNyHgWU=
-github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,7 @@ github.com/frozzare/go v1.0.0 h1:aMEQSDLZ9RRodFq03p9eFi10Oxg4YNek29a0ul86tc4=
 github.com/frozzare/go v1.0.0/go.mod h1:aF04gf7/Kbc1nTC3XyPCgWEBIpnRjhsGQ1aj4bCVxxk=
 github.com/frozzare/go-assert v1.1.0 h1:JaWK+Q2bFyVyE8dpUNtqh0P9CFAwtQhTiKZiwJ8R+Mc=
 github.com/frozzare/go-assert v1.1.0/go.mod h1:qaUtLVkASIEqsHEn8xhGKLh+24s1y07Y88Z5mNyHgWU=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/personnummer.go
+++ b/personnummer.go
@@ -29,8 +29,9 @@ var (
 		11: 30,
 		12: 31,
 	}
-	now   = time.Now
-	rule3 = [...]int{0, 2, 4, 6, 8, 1, 3, 5, 7, 9}
+	now            = time.Now
+	rule3          = [...]int{0, 2, 4, 6, 8, 1, 3, 5, 7, 9}
+	interimLetters = []rune("TRSUWXJKLMN")
 )
 
 // charsToDigit converts char bytes to a digit
@@ -48,6 +49,15 @@ func charsToDigit(chars []byte) int {
 	return r
 }
 
+func runeInSlice(a rune, list []rune) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
 // getCleanNumber will return clean numbers.
 func getCleanNumber(in string) []byte {
 	cleanNumber := make([]byte, 0, len(in))
@@ -60,11 +70,13 @@ func getCleanNumber(in string) []byte {
 			continue
 		}
 
-		if c > '9' {
-			return nil
-		}
-		if c < '0' {
-			return nil
+		if !runeInSlice(c, interimLetters) {
+			if c > '9' {
+				return nil
+			}
+			if c < '0' {
+				return nil
+			}
 		}
 
 		cleanNumber = append(cleanNumber, byte(c))
@@ -162,13 +174,20 @@ type Personnummer struct {
 
 // Options represents the personnummer options.
 type Options struct {
+	AllowInterimNumber        bool
+	DisableCoordinationNumber bool
 }
 
 // New parse a Swedish personal identity numbers and returns a new struct or a error.
 func New(pin string, options ...*Options) (*Personnummer, error) {
 	p := &Personnummer{}
+	o := &Options{}
 
-	if err := p.parse(pin); err != nil {
+	if len(options) > 0 {
+		o = options[0]
+	}
+
+	if err := p.parse(pin, o); err != nil {
 		return nil, err
 	}
 
@@ -176,7 +195,7 @@ func New(pin string, options ...*Options) (*Personnummer, error) {
 }
 
 // parse Swedish personal identity numbers and set struct properpties or return a error.
-func (p *Personnummer) parse(pin string) error {
+func (p *Personnummer) parse(pin string, options *Options) error {
 	var century, year, num, check string
 
 	if pin == "" {
@@ -266,12 +285,25 @@ func (p *Personnummer) parse(pin string) error {
 		return errInvalidSecurityNumber
 	}
 
+	if p.IsCoordinationNumber() && options.DisableCoordinationNumber {
+		return errInvalidSecurityNumber
+	}
+
+	if p.IsInterimNumber() && !options.AllowInterimNumber {
+		return errInvalidSecurityNumber
+	}
+
 	return nil
 }
 
 // Valid will validate Swedish personal identity numbers.
 func (p *Personnummer) valid() bool {
-	pin := fmt.Sprintf("%s%s%s%s%s%s", p.Century, p.Year, p.Month, p.Day, p.Num, p.Check)
+	num := p.Num
+	if p.IsInterimNumber() {
+		num = "1" + p.Num[1:]
+	}
+
+	pin := fmt.Sprintf("%s%s%s%s%s%s", p.Century, p.Year, p.Month, p.Day, num, p.Check)
 
 	bytes := []byte(pin)
 	if !luhn(bytes[2:]) {
@@ -326,6 +358,12 @@ func (p *Personnummer) IsCoordinationNumber() bool {
 		str += fmt.Sprintf("%d", day)
 	}
 	return validateTime([]byte(str))
+}
+
+// IsInterimNumber determine if a Swedish personal identity number is a interim number or not.
+// Returns true if it's a interim number.
+func (p *Personnummer) IsInterimNumber() bool {
+	return runeInSlice(rune(p.Num[0]), interimLetters)
 }
 
 // IsFemale checks if a Swedish personal identity number is for a female.

--- a/personnummer.go
+++ b/personnummer.go
@@ -293,8 +293,8 @@ func (p *Personnummer) Format(longFormat ...bool) (string, error) {
 	return fmt.Sprintf("%s%s%s%s%s%s", p.Year, p.Month, p.Day, p.Sep, p.Num, p.Check), nil
 }
 
-// GetAge returns the age from a Swedish personal identity number.
-func (p *Personnummer) GetAge() int {
+// GetDate returns the date from a Swedish personal identity number.
+func (p *Personnummer) GetDate() time.Time {
 	ageDay := charsToDigit([]byte(p.Day))
 
 	if p.IsCoordinationNumber() {
@@ -304,7 +304,12 @@ func (p *Personnummer) GetAge() int {
 	fullYear := charsToDigit([]byte(p.FullYear))
 	month := charsToDigit([]byte(p.Month))
 
-	t := time.Date(fullYear, time.Month(month), ageDay, 0, 0, 0, 0, time.UTC)
+	return time.Date(fullYear, time.Month(month), ageDay, 0, 0, 0, 0, time.UTC)
+}
+
+// GetAge returns the age from a Swedish personal identity number.
+func (p *Personnummer) GetAge() int {
+	t := p.GetDate()
 	a := math.Floor(float64(now().Sub(t)/1e6) / 3.15576e+10)
 
 	return int(a)

--- a/personnummer_test.go
+++ b/personnummer_test.go
@@ -118,6 +118,37 @@ func TestPersonnummerSex(t *testing.T) {
 	}
 }
 
+func TestPersonnummerDate(t *testing.T) {
+	for _, item := range testList {
+		if !item.Valid {
+			continue
+		}
+
+		year := item.SeparatedLong[0:4]
+		month := item.SeparatedLong[4:6]
+		day := item.SeparatedLong[6:8]
+
+		if item.Type == "con" {
+			nDay, _ := strconv.Atoi(day)
+			nDay = nDay - 60
+			day = fmt.Sprintf("%02d", nDay)
+			p, _ := Parse(item.SeparatedLong)
+			assert.Equal(t, true, p.IsCoordinationNumber())
+		}
+
+		tt, _ := time.Parse("2006-01-02", fmt.Sprintf("%s-%s-%s", year, month, day))
+
+		for _, format := range availableListFormats {
+			if format == "short_format" {
+				continue
+			}
+
+			p, _ := Parse(item.Get(format))
+			assert.Equal(t, tt, p.GetDate())
+		}
+	}
+}
+
 func TestPersonnummerAge(t *testing.T) {
 	for _, item := range testList {
 		if !item.Valid {


### PR DESCRIPTION
**Type of change**

- [x] New feature
- [ ] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

This PR contains the 3.1 spec features `GetDate` and interim numbers. I've changed `AllowCoordinationNumber` to `DisableCoordinationNumber` since it's hard to set `true` as default value in go when `false` is the default value for boolean and `sql.NullBool` and every other solutions isn't that great. The renaming of the option should be included in v4 of Personnummer spec since it's more sens to disable it than allowing it.

**Checklist**

- [x] I have read the **CONTRIBUTING** document.
- [x] I have read and accepted the **Code of conduct**
- [x] Tests passes.
- [x] Style lints passes.
- [x] Documentation of new public methods exists.
<!-- The following are only needed if this is a new feature. -->
<!-- - [ ] New tests added which covers the added code. -->
<!-- - [ ] Documentation is updated. -->
<!-- - [ ] This PR includes breaking changes. -->
